### PR TITLE
Upgrade to node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "4.4.3"
+  - "6.9.1"
 sudo: false
 before_install:
-  - npm install -g npm@2.13.5
+  - npm install -g npm@3.10.8
   - npm install -g grunt-cli
 install: npm install

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,10 +1,10 @@
 {
   "name": "fh-statsc",
-  "version": "0.2.4",
+  "version": "0.3.1",
   "dependencies": {
     "async": {
       "version": "0.2.9",
-      "from": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
+      "from": "async@0.2.9",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-statsc",
   "description": "FeedHenry Stats Client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
     "test": "grunt fh:test"
   },
   "engines": {
-    "node": "*"
+    "node": "6.9"
   },
   "bin": {
     "fh-statsc": "./bin/fh-statsc.js"
@@ -24,10 +24,10 @@
     "async": "0.2.9"
   },
   "devDependencies": {
-    "expresso": "^0.9.2",
-    "grunt": "^0.4.5",
-    "grunt-fh-build": "^0.5.0",
-    "istanbul": "^0.3.15",
+    "expresso": "~0.9.2",
+    "grunt": "~0.4.5",
+    "grunt-fh-build": "~1.0.2",
+    "istanbul": "~0.3.22",
     "proxyquire": "0.4.1"
   },
   "man": "./man/fh-statsc.1",


### PR DESCRIPTION
### Node 6 support:
- Update engines to node 6.9
- Change `^` to `~` in dependencies
- Remove node 0.10 and add node 6.9.1 in travis.yml
- Build script updated to build in Node 6: http://bob.feedhenry.net:8080/job/fh-statsc_pullrequests/configure

JIRA: https://issues.jboss.org/browse/RHMAP-16216